### PR TITLE
fix(mcp-server): Fix Cursor integration and protocol compatibility

### DIFF
--- a/packages/mcp-server/CURSOR_SETUP.md
+++ b/packages/mcp-server/CURSOR_SETUP.md
@@ -1,0 +1,145 @@
+# Cursor MCP Setup Guide
+
+This guide shows how to integrate the dev-agent MCP server with Cursor IDE.
+
+## Prerequisites
+
+1. Build the MCP server:
+   ```bash
+   cd /path/to/dev-agent
+   pnpm install
+   pnpm build
+   ```
+
+2. Ensure the repository is indexed:
+   ```bash
+   pnpm dev scan
+   ```
+
+## Configuration
+
+### 1. Locate Cursor's MCP Config
+
+The MCP configuration file is located at:
+- **macOS**: `~/Library/Application Support/Cursor/User/globalStorage/mcp.json`
+- **Linux**: `~/.config/Cursor/User/globalStorage/mcp.json`
+- **Windows**: `%APPDATA%\Cursor\User\globalStorage\mcp.json`
+
+### 2. Add dev-agent MCP Server
+
+Create or update the `mcp.json` file with the following configuration:
+
+```json
+{
+  "mcpServers": {
+    "dev-agent": {
+      "command": "node",
+      "args": [
+        "/absolute/path/to/dev-agent/packages/mcp-server/dist/bin/dev-agent-mcp.js"
+      ],
+      "env": {
+        "REPOSITORY_PATH": "/absolute/path/to/your/repository",
+        "LOG_LEVEL": "info"
+      }
+    }
+  }
+}
+```
+
+**Important:** Replace the paths with your actual absolute paths.
+
+### 3. Restart Cursor
+
+After updating the configuration, restart Cursor to load the MCP server.
+
+## Verification
+
+1. Open Cursor
+2. Try using the `dev_search` tool in a chat:
+   ```
+   Search for "authentication middleware" in the codebase
+   ```
+
+3. The MCP server should respond with semantic search results
+
+## Available Tools
+
+### `dev_search`
+
+Semantic code search across your repository.
+
+**Parameters:**
+- `query` (required): Natural language search query
+- `format` (optional): `compact` (default) or `verbose`
+- `limit` (optional): Number of results (1-50, default: 10)
+- `scoreThreshold` (optional): Minimum relevance score (0-1, default: 0)
+
+**Example:**
+```
+dev_search:
+  query: "user authentication logic"
+  format: compact
+  limit: 5
+```
+
+## Troubleshooting
+
+### Server Not Starting
+
+1. Check Cursor's logs (Help > Show Logs)
+2. Verify the paths in `mcp.json` are absolute and correct
+3. Ensure the server builds successfully: `pnpm build`
+4. Test the server manually:
+   ```bash
+   echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"1.0","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}' | \
+     node /path/to/dev-agent/packages/mcp-server/dist/bin/dev-agent-mcp.js
+   ```
+
+### Repository Not Indexed
+
+If searches return no results:
+```bash
+cd /path/to/your/repository
+/path/to/dev-agent/packages/cli/dist/index.js scan
+```
+
+### Logs
+
+Set `LOG_LEVEL` to `debug` in the env section of `mcp.json` for more verbose logging:
+```json
+"env": {
+  "REPOSITORY_PATH": "/path/to/repo",
+  "LOG_LEVEL": "debug"
+}
+```
+
+## Multiple Repositories
+
+To use dev-agent with multiple repositories, add multiple server configurations:
+
+```json
+{
+  "mcpServers": {
+    "dev-agent-project-a": {
+      "command": "node",
+      "args": ["/path/to/dev-agent/packages/mcp-server/dist/bin/dev-agent-mcp.js"],
+      "env": {
+        "REPOSITORY_PATH": "/path/to/project-a"
+      }
+    },
+    "dev-agent-project-b": {
+      "command": "node",
+      "args": ["/path/to/dev-agent/packages/mcp-server/dist/bin/dev-agent-mcp.js"],
+      "env": {
+        "REPOSITORY_PATH": "/path/to/project-b"
+      }
+    }
+  }
+}
+```
+
+## Next Steps
+
+- See [README.md](./README.md) for general MCP server documentation
+- See [../../docs/WORKFLOW.md](../../docs/WORKFLOW.md) for the dev-agent workflow
+

--- a/packages/mcp-server/bin/dev-agent-mcp.ts
+++ b/packages/mcp-server/bin/dev-agent-mcp.ts
@@ -1,0 +1,68 @@
+#!/usr/bin/env node
+/**
+ * dev-agent MCP Server Entry Point
+ * Starts the MCP server with stdio transport for AI tools (Claude, Cursor, etc.)
+ */
+
+import { RepositoryIndexer } from '@lytics/dev-agent-core';
+import { SearchAdapter } from '../src/adapters/built-in/search-adapter';
+import { MCPServer } from '../src/server/mcp-server';
+
+// Get config from environment
+const repositoryPath = process.env.REPOSITORY_PATH || process.cwd();
+const vectorStorePath =
+  process.env.VECTOR_STORE_PATH || `${repositoryPath}/.dev-agent/vectors.lance`;
+const logLevel = (process.env.LOG_LEVEL as 'debug' | 'info' | 'warn' | 'error') || 'info';
+
+async function main() {
+  try {
+    // Initialize repository indexer
+    const indexer = new RepositoryIndexer({
+      repositoryPath,
+      vectorStorePath,
+    });
+
+    await indexer.initialize();
+
+    // Create and register adapters
+    const searchAdapter = new SearchAdapter({
+      repositoryIndexer: indexer,
+      defaultFormat: 'compact',
+      defaultLimit: 10,
+    });
+
+    // Create MCP server
+    const server = new MCPServer({
+      serverInfo: {
+        name: 'dev-agent',
+        version: '0.1.0',
+      },
+      config: {
+        repositoryPath,
+        logLevel,
+      },
+      transport: 'stdio',
+      adapters: [searchAdapter],
+    });
+
+    // Handle graceful shutdown
+    const shutdown = async () => {
+      await server.stop();
+      await indexer.close();
+      process.exit(0);
+    };
+
+    process.on('SIGINT', shutdown);
+    process.on('SIGTERM', shutdown);
+
+    // Start server
+    await server.start();
+
+    // Keep process alive (server runs until stdin closes or signal received)
+  } catch (error) {
+    console.error('Failed to start MCP server:', error);
+    process.exit(1);
+  }
+}
+
+main();

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -6,7 +6,7 @@
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "bin": {
-    "dev-agent-mcp": "./dist/index.js"
+    "dev-agent-mcp": "./dist/bin/dev-agent-mcp.js"
   },
   "scripts": {
     "build": "tsc",

--- a/packages/mcp-server/src/server/transport/stdio-transport.ts
+++ b/packages/mcp-server/src/server/transport/stdio-transport.ts
@@ -20,9 +20,9 @@ export class StdioTransport extends Transport {
     }
 
     // Create readline interface for line-by-line input
+    // Note: We don't specify 'output' to avoid readline echoing input to stdout
     this.readline = readline.createInterface({
       input: process.stdin,
-      output: process.stdout,
       terminal: false,
     });
 

--- a/packages/mcp-server/src/utils/logger.ts
+++ b/packages/mcp-server/src/utils/logger.ts
@@ -5,20 +5,30 @@
 import type { Logger } from '../adapters/types';
 
 export class ConsoleLogger implements Logger {
-  constructor(private prefix = '[MCP]') {}
+  constructor(
+    private prefix = '[MCP]',
+    private minLevel: 'debug' | 'info' | 'warn' | 'error' = 'info'
+  ) {}
 
   debug(message: string, meta?: Record<string, unknown>): void {
-    if (process.env.DEBUG) {
-      console.debug(`${this.prefix} DEBUG:`, message, meta || '');
+    if (this.minLevel === 'debug') {
+      // MCP requires all logs on stderr (stdout is for JSON-RPC only)
+      console.error(`${this.prefix} DEBUG:`, message, meta || '');
     }
   }
 
   info(message: string, meta?: Record<string, unknown>): void {
-    console.info(`${this.prefix} INFO:`, message, meta ? JSON.stringify(meta) : '');
+    if (this.minLevel === 'debug' || this.minLevel === 'info') {
+      // MCP requires all logs on stderr (stdout is for JSON-RPC only)
+      console.error(`${this.prefix} INFO:`, message, meta ? JSON.stringify(meta) : '');
+    }
   }
 
   warn(message: string, meta?: Record<string, unknown>): void {
-    console.warn(`${this.prefix} WARN:`, message, meta ? JSON.stringify(meta) : '');
+    if (this.minLevel !== 'error') {
+      // MCP requires all logs on stderr (stdout is for JSON-RPC only)
+      console.error(`${this.prefix} WARN:`, message, meta ? JSON.stringify(meta) : '');
+    }
   }
 
   error(message: string | Error, meta?: Record<string, unknown>): void {

--- a/packages/mcp-server/tsconfig.json
+++ b/packages/mcp-server/tsconfig.json
@@ -2,12 +2,12 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "outDir": "./dist",
-    "rootDir": "./src",
+    "rootDir": ".",
     "composite": true,
     "declaration": true,
     "declarationMap": true
   },
-  "include": ["src/**/*"],
+  "include": ["src/**/*", "bin/**/*"],
   "exclude": ["node_modules", "dist", "**/*.test.ts"],
   "references": [
     { "path": "../core" },


### PR DESCRIPTION
## Problem

The MCP server was immediately disconnecting when Cursor tried to connect, resulting in 'No server info found' errors. This was due to several issues:

1. **Protocol version mismatch**: We were responding with '1.0' but Cursor expects date-based versioning (e.g., '2025-06-18')
2. **Missing notification handler**: The `initialized` notification wasn't being handled, causing Cursor to close the connection
3. **Stdout interference**: Logger was writing to stdout, corrupting JSON-RPC messages
4. **Readline output**: readline was configured to echo to stdout

## Solution

- Echo back the client's protocol version instead of hardcoding '1.0'
- Add explicit handling for the `initialized` notification
- Fix logger to write all messages to stderr (not stdout)
- Remove readline output configuration to prevent echoing
- Enable debug logging to aid future troubleshooting
- Add CLI entry point (`dev-agent-mcp.ts`) for starting the server

## Testing

✅ MCP server successfully connects to Cursor
✅ `dev_search` tool is discovered and functional
✅ End-to-end search works in Cursor chat
✅ All pre-commit hooks pass (linting + type checking)

## Related Issues

Fixes issues discovered during dogfooding of the MCP server integration (Issues #27, #28).