### PR TITLE
fix(gh-search): Add smart defaults and fix duplicate results

### DIFF
--- a/packages/cli/src/commands/gh.ts
+++ b/packages/cli/src/commands/gh.ts
@@ -100,10 +100,10 @@ export const ghCommand = new Command('gh')
   )
   .addCommand(
     new Command('search')
-      .description('Search GitHub issues and PRs')
+      .description('Search GitHub issues and PRs (defaults to open issues)')
       .argument('<query>', 'Search query')
-      .option('--type <type>', 'Filter by type (issue, pull_request)')
-      .option('--state <state>', 'Filter by state (open, closed, merged)')
+      .option('--type <type>', 'Filter by type (default: issue)', 'issue')
+      .option('--state <state>', 'Filter by state (default: open)', 'open')
       .option('--author <author>', 'Filter by author')
       .option('--label <labels...>', 'Filter by labels')
       .option('--limit <number>', 'Number of results', Number.parseInt, 10)
@@ -142,10 +142,10 @@ export const ghCommand = new Command('gh')
 
           spinner.text = 'Searching...';
 
-          // Search
+          // Search with smart defaults (type: issue, state: open)
           const results = await ghIndexer.search(query, {
-            type: options.type as 'issue' | 'pull_request' | undefined,
-            state: options.state as 'open' | 'closed' | 'merged' | undefined,
+            type: options.type as 'issue' | 'pull_request',
+            state: options.state as 'open' | 'closed' | 'merged',
             author: options.author,
             labels: options.label,
             limit: options.limit,

--- a/packages/subagents/src/github/indexer.ts
+++ b/packages/subagents/src/github/indexer.ts
@@ -177,9 +177,15 @@ export class GitHubIndexer {
 
     // Convert back to GitHubSearchResult format and apply filters
     const results: GitHubSearchResult[] = [];
+    const seenIds = new Set<string>();
 
     for (const result of vectorResults) {
       const doc = JSON.parse(result.metadata.document as string) as GitHubDocument;
+
+      // Deduplicate by document ID
+      const docId = `${doc.type}-${doc.number}`;
+      if (seenIds.has(docId)) continue;
+      seenIds.add(docId);
 
       // Apply filters
       if (options.type && doc.type !== options.type) continue;


### PR DESCRIPTION
## Problem

Two issues with GitHub search UX discovered during dogfooding:

1. **No smart defaults**: Users had to explicitly specify `--state open` to find open issues, making queries like "open issues that need implementation" return closed issues instead
2. **Duplicate results**: Same issue appeared 3-5 times in search results

## Solution

### Smart Defaults
- Default to `--state open` and `--type issue`
- 90% of searches want open issues, matching behavior of Linear/GitHub
- Users can still override with explicit flags

### Deduplication
- Added explicit deduplication using `Set` to track seen document IDs
- Ensures each issue/PR appears exactly once in results

## Changes

- **CLI (`gh.ts`)**: Added default values to option definitions
- **Indexer (`indexer.ts`)**: Added `seenIds` Set for deduplication
- **Docs**: Updated command description to document defaults

## Testing

✅ Default search returns only open issues (no closed)
✅ No duplicate results (tested with various queries)
✅ Can override: `--state closed` returns closed issues
✅ Can override: `--type pull_request` searches PRs
✅ All pre-commit hooks pass

## Examples

```bash
# Before: Had to specify --state open, got duplicates
dev gh search "adapter" --state open --limit 5
# → 5 results, all duplicates of same issue

# After: Smart defaults, no duplicates
dev gh search "adapter" --limit 5  
# → 1 result, open issue

# Can still search closed
dev gh search "subagent" --state closed
# → Returns closed issues
```