### PR TITLE
fix: replace dynamic import with static import for GitHubIndexer

### DIFF
--- a/packages/mcp-server/src/adapters/built-in/github-adapter.ts
+++ b/packages/mcp-server/src/adapters/built-in/github-adapter.ts
@@ -3,11 +3,11 @@
  * Exposes GitHub context and search capabilities via MCP (dev_gh tool)
  */
 
-import type {
-  GitHubDocument,
+import {
+  type GitHubDocument,
   GitHubIndexer,
-  GitHubSearchOptions,
-  GitHubSearchResult,
+  type GitHubSearchOptions,
+  type GitHubSearchResult,
 } from '@lytics/dev-agent-subagents';
 import { estimateTokensForText } from '../../formatters/utils';
 import { ToolAdapter } from '../tool-adapter';
@@ -84,8 +84,6 @@ export class GitHubAdapter extends ToolAdapter {
     }
 
     // Lazy initialization
-    const { GitHubIndexer: GitHubIndexerClass } = await import('@lytics/dev-agent-subagents');
-
     // Try to load repository from state file to avoid gh CLI call
     let repository: string | undefined;
     try {
@@ -98,7 +96,7 @@ export class GitHubAdapter extends ToolAdapter {
       // GitHubIndexer will try gh CLI as fallback
     }
 
-    this.githubIndexer = new GitHubIndexerClass(
+    this.githubIndexer = new GitHubIndexer(
       {
         vectorStorePath: this.vectorStorePath,
         statePath: this.statePath,


### PR DESCRIPTION
## Problem
The `dev_gh` MCP tool was failing with error:
```
MCP error -32001: GitHubIndexerClass is not a constructor
```

## Root Cause
The dynamic import in `github-adapter.ts` was not correctly importing the `GitHubIndexer` class:
```typescript
const { GitHubIndexer: GitHubIndexerClass } = await import('@lytics/dev-agent-subagents');
```

## Solution
Changed to static import to match the pattern used in `status-adapter.ts`:
```typescript
import {
  GitHubIndexer,
  type GitHubDocument,
  type GitHubSearchOptions,
  type GitHubSearchResult,
} from '@lytics/dev-agent-subagents';
```

## Changes
- ✅ Replaced dynamic `import()` with static named import
- ✅ Now uses direct instantiation with `new GitHubIndexer()`
- ✅ Consistent with status-adapter.ts implementation

## Testing
- ✅ Build successful
- ✅ Manual testing confirmed `dev_gh` tool works correctly
- ✅ Both search and context actions verified

## Impact
- Fixes `dev_gh` tool functionality in MCP server
- Users can now search GitHub issues/PRs via MCP