### PR TITLE
fix: GitHub MCP adapter storage paths and resource list handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,7 @@ Thumbs.db
 # Dev-agent local data
 .dev-agent.json
 .dev-agent/
+
+# Temporary files and invalid paths
+temp/
+*-github/

--- a/packages/subagents/src/github/indexer.ts
+++ b/packages/subagents/src/github/indexer.ts
@@ -305,10 +305,11 @@ export class GitHubIndexer {
     const id = `${type}-${number}`;
 
     try {
-      const results = await this.vectorStorage.search(id, { limit: 1 });
-      if (results.length === 0) return null;
+      // Use exact ID lookup instead of semantic search
+      const result = await this.vectorStorage.getDocument(id);
+      if (!result) return null;
 
-      return JSON.parse(results[0].metadata.document as string) as GitHubDocument;
+      return JSON.parse(result.metadata.document as string) as GitHubDocument;
     } catch {
       return null;
     }


### PR DESCRIPTION
## Summary
- Fix MCP server resources/list method not implemented error
- Update GitHub CLI commands to use centralized storage
- Add path validation to prevent undefined storage paths
- Update GitHub adapter to use exact ID lookups
- Add temp/ directory for invalid paths with gitignore patterns

## Test plan
- [x] All 971 tests passing
- [x] Lint and format checks passing
- [x] TypeScript compilation successful
- [x] MCP server no longer shows as failed in tool integration
- [x] GitHub adapter works with both CLI and MCP server
- [x] No more undefined-github/ directories created