### PR TITLE
feat(mcp): add auto-reload for GitHub index updates

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -16,6 +16,18 @@
       }
     }
   },
+  "overrides": [
+    {
+      "includes": ["**/*.test.ts", "**/*.spec.ts", "**/__tests__/**"],
+      "linter": {
+        "rules": {
+          "suspicious": {
+            "noExplicitAny": "off"
+          }
+        }
+      }
+    }
+  ],
   "formatter": {
     "enabled": true,
     "indentWidth": 2,

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -136,6 +136,30 @@ The MCP server provides 5 powerful adapters (tools) and 8 guided prompts:
    - Semantic search with filters
    - Full context retrieval
    - Offline operation with cache
+   - **Auto-reload**: Automatically picks up new data when `dev gh index` runs
+
+### Auto-Reload Feature
+
+The GitHub adapter automatically reloads index data when it detects changes, eliminating the need to restart the MCP server:
+
+- **How it works**: Monitors GitHub state file modification time
+- **When it reloads**: On next query after `dev gh index` updates the data
+- **No user action required**: Changes are picked up automatically
+- **Efficient**: Only checks file timestamps (no polling)
+
+**Example workflow:**
+```bash
+# 1. Query GitHub data in Claude Code/Cursor
+> Use dev_gh to search for "authentication issues"
+
+# 2. Update the index (in terminal)
+$ dev gh index
+✓ Indexed 59 documents (32 issues + 27 PRs)
+
+# 3. Query again - new data appears automatically!
+> Use dev_gh to search for "authentication issues"
+# Results now include newly created issues #58, #59
+```
 
 ### Prompts (Guided Workflows)
 
@@ -368,7 +392,7 @@ All adapters are fully tested and production-ready:
 
 - **StatusAdapter** (`dev_status`) - Repository health and statistics
   - Code index status
-  - GitHub integration status
+  - GitHub integration status (auto-reloads on change)
   - Health checks and storage metrics
 
 - **PlanAdapter** (`dev_plan`) - Implementation planning from GitHub issues
@@ -385,6 +409,7 @@ All adapters are fully tested and production-ready:
   - Semantic search with filters
   - Full context retrieval
   - Works offline with cached data
+  - **Auto-reload**: Automatically picks up index updates without restart
   - Token cost display: 🪙 ~36 tokens (compact) to ~462 tokens (verbose)
 
 ## Configuration
@@ -530,7 +555,6 @@ console.log(tools);
 - ⚠️ Stdio transport only (HTTP planned for v2)
 - ⚠️ Sequential tool execution (parallel execution planned)
 - ⚠️ No built-in authentication (use OS-level permissions)
-- ⚠️ No adapter hot-reloading (restart required)
 
 **Planned Features:**
 - HTTP/WebSocket transport (#31)


### PR DESCRIPTION
## Overview

Implements automatic reload mechanism for GitHubAdapter and StatusAdapter that detects when `dev gh index` updates the GitHub state file and automatically reloads the index without requiring MCP server restart.

## Problem

When users ran `dev gh index` to update the GitHub data, the MCP server (running in Claude Code/Cursor) would continue using the old, stale data loaded at startup. Users had to manually restart the MCP server to pick up the new data - this meant newly indexed issues (#58, #59) were not visible.

## Solution

Implemented **file modification time checking** to automatically reload the GitHub index when the state file changes:

1. **Track Last Modified Time**: Store the `mtime` when the index is first loaded
2. **Check Before Each Operation**: Before executing any GitHub-related operation, check if the state file `mtime` has changed
3. **Reload if Changed**: If the file was modified (by `dev gh index`), automatically reload the indexer

## Changes

- Track GitHub state file modification time (`mtime`)
- Check for file changes before each operation  
- Automatically reload indexer when state file is updated
- Apply to both GitHubAdapter and StatusAdapter
- Add comprehensive unit tests for reload behavior (all 21 tests passing ✅)
- Update README with auto-reload documentation
- Configure Biome to allow `any` in test files

## Benefits

- ✅ No manual restart required after index updates
- ✅ Immediate visibility of new issues/PRs
- ✅ Event-driven (on-demand check), not polling-based
- ✅ Efficient file modification time checking

## Testing

- Unit tests added for file modification detection
- All existing tests still pass
- Manual testing confirmed auto-reload works

## Example Workflow

```bash
# 1. Query GitHub data in Claude Code/Cursor
> Use dev_gh to search for "authentication issues"

# 2. Update the index (in terminal)
$ dev gh index
✓ Indexed 59 documents (32 issues + 27 PRs)

# 3. Query again - new data appears automatically!
> Use dev_gh to search for "authentication issues"
# Results now include newly created issues #58, #59
```

## Related Issues

Fixes the issue where duplicate issues #58 and #59 couldn't be seen by the MCP server after running `dev gh index`.