### PR TITLE
feat(core): store code snippets during indexing

### DIFF
--- a/packages/core/src/scanner/types.ts
+++ b/packages/core/src/scanner/types.ts
@@ -26,6 +26,7 @@ export interface DocumentMetadata {
   signature?: string; // Full signature
   exported: boolean; // Is it a public API?
   docstring?: string; // Documentation comment
+  snippet?: string; // Actual code content (truncated if large)
 
   // Extensible for future use
   custom?: Record<string, unknown>;


### PR DESCRIPTION
## Summary

Implements #67 - First sub-issue of Epic #66 (Richer Search Results)

## Changes

### `packages/core/src/scanner/types.ts`
- Added `snippet?: string` field to `DocumentMetadata` interface

### `packages/core/src/scanner/typescript.ts`
- Added `DEFAULT_MAX_SNIPPET_LINES` constant (50 lines)
- Added `truncateSnippet()` helper method
- Updated all extraction methods to capture full code content:
  - `extractFunction`
  - `extractClass`
  - `extractMethod`
  - `extractInterface`
  - `extractTypeAlias`

### `packages/core/src/scanner/__tests__/scanner.test.ts`
- Added 7 new tests for snippet extraction:
  - Extract snippets for classes
  - Extract snippets for functions
  - Extract snippets for interfaces
  - Extract snippets for type aliases
  - Extract snippets for methods
  - Truncate long snippets
  - Preserve formatting and indentation

## Behavior

The scanner now captures actual code content, not just metadata:

- **Small components (<50 lines)**: Full code content stored
- **Large components (>50 lines)**: Truncated with `// ... N more lines` indicator
- **Formatting**: Original indentation and formatting preserved

## Testing

- All 28 scanner tests pass
- TypeScript compiles without errors
- Biome linting passes

## Related Issues

- Closes #67
- Part of Epic #66