### PR TITLE
feat(core): track import/export relationships during indexing

### DIFF
--- a/packages/core/src/scanner/types.ts
+++ b/packages/core/src/scanner/types.ts
@@ -27,6 +27,7 @@ export interface DocumentMetadata {
   exported: boolean; // Is it a public API?
   docstring?: string; // Documentation comment
   snippet?: string; // Actual code content (truncated if large)
+  imports?: string[]; // File-level imports (module specifiers)
 
   // Extensible for future use
   custom?: Record<string, unknown>;


### PR DESCRIPTION
## Summary

Implements #68 - Second sub-issue of Epic #66 (Richer Search Results)

## Changes

### `packages/core/src/scanner/types.ts`
- Added `imports?: string[]` field to `DocumentMetadata` interface

### `packages/core/src/scanner/typescript.ts`
- Added `extractImports()` method to extract module specifiers
- Updated `extractFromSourceFile()` to extract imports once per file
- Updated all extraction methods to accept and include imports:
  - `extractFunction`
  - `extractClass`
  - `extractMethod`
  - `extractInterface`
  - `extractTypeAlias`

### `packages/core/src/scanner/__tests__/scanner.test.ts`
- Added 9 new tests for import extraction

## Features

✅ Handles relative imports (`./service`)
✅ Handles package imports (`express`)
✅ Handles scoped packages (`@lytics/dev-agent-core`)
✅ Handles node builtins (`node:path`)
✅ Handles re-exports (`export { x } from "./bar"`)
✅ Files with no imports return empty array

## Testing

- ✅ 37 tests, all passing
- ✅ 9 new import extraction tests
- ✅ TypeScript compiles without errors
- ✅ Biome linting passes

## Example Output

```typescript
{
  "name": "TypeScriptScanner",
  "file": "packages/core/src/scanner/typescript.ts",
  "imports": ["node:path", "ts-morph", "./types"],
  "exported": true
}
```

## Related Issues

- Closes #68
- Part of Epic #66