### PR TITLE
feat(core): extend SearchResult type with snippet and imports

### DIFF
--- a/packages/core/src/indexer/utils/documents.ts
+++ b/packages/core/src/indexer/utils/documents.ts
@@ -39,6 +39,8 @@ export function prepareDocumentsForEmbedding(documents: Document[]): EmbeddingDo
       exported: doc.metadata.exported,
       signature: doc.metadata.signature,
       docstring: doc.metadata.docstring,
+      snippet: doc.metadata.snippet,
+      imports: doc.metadata.imports,
     },
   }));
 }
@@ -72,6 +74,8 @@ export function prepareDocumentForEmbedding(doc: Document): EmbeddingDocument {
       exported: doc.metadata.exported,
       signature: doc.metadata.signature,
       docstring: doc.metadata.docstring,
+      snippet: doc.metadata.snippet,
+      imports: doc.metadata.imports,
     },
   };
 }

--- a/packages/core/src/vector/store.ts
+++ b/packages/core/src/vector/store.ts
@@ -1,6 +1,12 @@
 import type { Connection, Table } from '@lancedb/lancedb';
 import * as lancedb from '@lancedb/lancedb';
-import type { EmbeddingDocument, SearchOptions, SearchResult, VectorStore } from './types';
+import type {
+  EmbeddingDocument,
+  SearchOptions,
+  SearchResult,
+  SearchResultMetadata,
+  VectorStore,
+} from './types';
 
 /**
  * Vector store implementation using LanceDB
@@ -119,7 +125,7 @@ export class LanceDBVectorStore implements VectorStore {
           return {
             id: result.id as string,
             score,
-            metadata: JSON.parse(result.metadata as string) as Record<string, unknown>,
+            metadata: JSON.parse(result.metadata as string) as SearchResultMetadata,
           };
         })
         .filter((result) => result.score >= scoreThreshold);

--- a/packages/core/src/vector/types.ts
+++ b/packages/core/src/vector/types.ts
@@ -2,6 +2,8 @@
  * Vector storage and embedding types
  */
 
+import type { DocumentType } from '../scanner/types';
+
 /**
  * Document to be embedded and stored
  */
@@ -12,12 +14,36 @@ export interface EmbeddingDocument {
 }
 
 /**
+ * Metadata stored in search results
+ * Maps from DocumentMetadata with 'file' renamed to 'path' for convenience
+ *
+ * This interface provides type hints for common fields while allowing
+ * additional custom fields for different use cases (e.g., GitHub indexer).
+ */
+export interface SearchResultMetadata {
+  // Core fields (present in code search results)
+  path?: string; // File path (mapped from DocumentMetadata.file)
+  type?: DocumentType | string; // Type of code element (or custom type)
+  language?: string; // Programming language
+  name?: string; // Symbol name
+  startLine?: number; // Start line number
+  endLine?: number; // End line number
+  exported?: boolean; // Is it a public API?
+  signature?: string; // Full signature
+  docstring?: string; // Documentation comment
+  snippet?: string; // Actual code content (truncated if large)
+  imports?: string[]; // File-level imports (module specifiers)
+  // Allow additional custom fields for extensibility (e.g., GitHub indexer uses 'document')
+  [key: string]: unknown;
+}
+
+/**
  * Search result from vector store
  */
 export interface SearchResult {
   id: string;
   score: number; // Cosine similarity score (0-1)
-  metadata: Record<string, unknown>;
+  metadata: SearchResultMetadata;
 }
 
 /**


### PR DESCRIPTION
## Summary

Implements #69 - Third sub-issue of Epic #66 (Richer Search Results)

## Changes

### `packages/core/src/vector/types.ts`
- Added `SearchResultMetadata` interface with typed fields
- Updated `SearchResult` to use `SearchResultMetadata` instead of `Record<string, unknown>`

### `packages/core/src/vector/store.ts`
- Updated `search()` to cast parsed metadata to `SearchResultMetadata`

### `packages/core/src/indexer/utils/documents.ts`
- Added `snippet` and `imports` to `prepareDocumentsForEmbedding()`
- Added `snippet` and `imports` to `prepareDocumentForEmbedding()`

## SearchResultMetadata Fields

```typescript
interface SearchResultMetadata {
  path?: string;       // File path
  type?: DocumentType | string;
  language?: string;
  name?: string;
  startLine?: number;
  endLine?: number;
  exported?: boolean;
  signature?: string;
  docstring?: string;
  snippet?: string;    // NEW: from #67
  imports?: string[];  // NEW: from #68
  [key: string]: unknown;  // Extensible
}
```

## Features

✅ Typed metadata fields with IDE autocomplete
✅ Backward compatible (all fields optional)
✅ Extensible via index signature for custom use cases
✅ `snippet` and `imports` now flow through to search results

## Testing

- ✅ 1265 tests passing
- ✅ TypeScript compiles without errors
- ✅ Biome linting passes

## Related Issues

- Closes #69
- Part of Epic #66
- Depends on #67 (snippet) and #68 (imports)