### PR TITLE
feat(mcp): update formatters for rich search results

### DIFF
--- a/packages/mcp-server/src/formatters/compact-formatter.ts
+++ b/packages/mcp-server/src/formatters/compact-formatter.ts
@@ -7,9 +7,14 @@ import type { SearchResult } from '@lytics/dev-agent-core';
 import type { FormattedResult, FormatterOptions, ResultFormatter } from './types';
 import { estimateTokensForText } from './utils';
 
+/** Default max snippet lines for compact mode */
+const DEFAULT_MAX_SNIPPET_LINES = 10;
+/** Max imports to show before truncating */
+const MAX_IMPORTS_DISPLAY = 5;
+
 /**
  * Compact formatter - optimized for token efficiency
- * Returns: path, type, name, score
+ * Returns: path, type, name, score, optional snippet and imports
  */
 export class CompactFormatter implements ResultFormatter {
   private options: Required<FormatterOptions>;
@@ -21,14 +26,45 @@ export class CompactFormatter implements ResultFormatter {
       includeLineNumbers: options.includeLineNumbers ?? true,
       includeTypes: options.includeTypes ?? true,
       includeSignatures: options.includeSignatures ?? false, // Compact mode excludes signatures
+      includeSnippets: options.includeSnippets ?? false, // Off by default for compact
+      includeImports: options.includeImports ?? false, // Off by default for compact
+      maxSnippetLines: options.maxSnippetLines ?? DEFAULT_MAX_SNIPPET_LINES,
       tokenBudget: options.tokenBudget ?? 1000,
     };
   }
 
   formatResult(result: SearchResult): string {
+    const lines: string[] = [];
+
+    // Line 1: Header with score, type, name, path
+    lines.push(this.formatHeader(result));
+
+    // Code snippet (if enabled)
+    if (this.options.includeSnippets && typeof result.metadata.snippet === 'string') {
+      const truncatedSnippet = this.truncateSnippet(
+        result.metadata.snippet,
+        this.options.maxSnippetLines
+      );
+      lines.push(this.indentText(truncatedSnippet, 3));
+    }
+
+    // Imports (if enabled)
+    if (this.options.includeImports && Array.isArray(result.metadata.imports)) {
+      const imports = result.metadata.imports as string[];
+      if (imports.length > 0) {
+        const displayImports = imports.slice(0, MAX_IMPORTS_DISPLAY);
+        const suffix = imports.length > MAX_IMPORTS_DISPLAY ? ' ...' : '';
+        lines.push(`   Imports: ${displayImports.join(', ')}${suffix}`);
+      }
+    }
+
+    return lines.join('\n');
+  }
+
+  private formatHeader(result: SearchResult): string {
     const parts: string[] = [];
 
-    // Score (2 decimals)
+    // Score
     parts.push(`[${(result.score * 100).toFixed(0)}%]`);
 
     // Type
@@ -41,7 +77,7 @@ export class CompactFormatter implements ResultFormatter {
       parts.push(result.metadata.name);
     }
 
-    // Path
+    // Path with line numbers
     if (this.options.includePaths && typeof result.metadata.path === 'string') {
       const pathPart =
         this.options.includeLineNumbers && typeof result.metadata.startLine === 'number'
@@ -51,6 +87,24 @@ export class CompactFormatter implements ResultFormatter {
     }
 
     return parts.join(' ');
+  }
+
+  private truncateSnippet(snippet: string, maxLines: number): string {
+    const lines = snippet.split('\n');
+    if (lines.length <= maxLines) {
+      return snippet;
+    }
+    const truncated = lines.slice(0, maxLines).join('\n');
+    const remaining = lines.length - maxLines;
+    return `${truncated}\n// ... ${remaining} more lines`;
+  }
+
+  private indentText(text: string, spaces: number): string {
+    const indent = ' '.repeat(spaces);
+    return text
+      .split('\n')
+      .map((line) => indent + line)
+      .join('\n');
   }
 
   formatResults(results: SearchResult[]): FormattedResult {
@@ -82,6 +136,17 @@ export class CompactFormatter implements ResultFormatter {
   }
 
   estimateTokens(result: SearchResult): number {
-    return estimateTokensForText(this.formatResult(result));
+    let estimate = estimateTokensForText(this.formatHeader(result));
+
+    if (this.options.includeSnippets && typeof result.metadata.snippet === 'string') {
+      estimate += estimateTokensForText(result.metadata.snippet);
+    }
+
+    if (this.options.includeImports && Array.isArray(result.metadata.imports)) {
+      // ~3 tokens per import path
+      estimate += (result.metadata.imports as string[]).length * 3;
+    }
+
+    return estimate;
   }
 }

--- a/packages/mcp-server/src/formatters/types.ts
+++ b/packages/mcp-server/src/formatters/types.ts
@@ -68,6 +68,21 @@ export interface FormatterOptions {
   includeSignatures?: boolean;
 
   /**
+   * Include code snippets in output
+   */
+  includeSnippets?: boolean;
+
+  /**
+   * Include import lists in output
+   */
+  includeImports?: boolean;
+
+  /**
+   * Maximum lines to show in snippets (default: 10 compact, 20 verbose)
+   */
+  maxSnippetLines?: number;
+
+  /**
    * Token budget (soft limit)
    */
   tokenBudget?: number;


### PR DESCRIPTION
## Summary

Implements #70 - Fourth sub-issue of Epic #66 (Richer Search Results)

## Changes

### `packages/mcp-server/src/formatters/types.ts`
- Added `includeSnippets?: boolean`
- Added `includeImports?: boolean`
- Added `maxSnippetLines?: number`

### `packages/mcp-server/src/formatters/compact-formatter.ts`
- Snippets/imports off by default (token efficient)
- Added `formatHeader()`, `truncateSnippet()`, `indentText()` helpers
- Max 5 imports shown with "..." truncation
- Updated `estimateTokens()` for new content

### `packages/mcp-server/src/formatters/verbose-formatter.ts`
- Snippets/imports on by default (full context)
- Shows location with line range (e.g., `file.ts:45-67`)
- Added same helper methods
- Updated `estimateTokens()` for new content

### `packages/mcp-server/src/formatters/__tests__/formatters.test.ts`
- Added 17 new tests for snippet/import formatting

## Example Output

### Compact (with options enabled)
```
1. [85%] function: handleAuth (src/auth/handler.ts:45)
   export async function handleAuth(req: Request) {
     const token = extractToken(req);
     // ... 15 more lines
   }
   Imports: ./service, ../utils/jwt, express
```

### Verbose (default)
```
1. [Score: 85.0%] function: handleAuth
  Location: src/auth/handler.ts:45-67
  Signature: async handleAuth(req: Request): Promise<Response>
  Imports: ./service, ../utils/jwt, express
  Metadata: language: typescript, exported: true, lines: 23
  Code:
    export async function handleAuth(req: Request) {
      const token = extractToken(req);
      // ... 15 more lines
    }
```

## Testing

- ✅ 1282 tests passing (17 new)
- ✅ TypeScript compiles without errors
- ✅ Biome linting passes

## Related Issues

- Closes #70
- Part of Epic #66