### PR TITLE
feat(mcp): token budget management with progressive disclosure

### DIFF
--- a/packages/mcp-server/src/formatters/compact-formatter.ts
+++ b/packages/mcp-server/src/formatters/compact-formatter.ts
@@ -1,20 +1,26 @@
 /**
  * Compact Formatter
- * Token-efficient formatter that returns summaries only
+ * Token-efficient formatter with progressive disclosure support
  */
 
 import type { SearchResult } from '@lytics/dev-agent-core';
-import type { FormattedResult, FormatterOptions, ResultFormatter } from './types';
+import type { DetailLevel, FormattedResult, FormatterOptions, ResultFormatter } from './types';
 import { estimateTokensForText } from './utils';
 
 /** Default max snippet lines for compact mode */
 const DEFAULT_MAX_SNIPPET_LINES = 10;
 /** Max imports to show before truncating */
 const MAX_IMPORTS_DISPLAY = 5;
+/** Default token budget */
+const DEFAULT_TOKEN_BUDGET = 2000;
+/** Default number of results with full detail */
+const DEFAULT_FULL_DETAIL_COUNT = 3;
+/** Default number of results with signature detail */
+const DEFAULT_SIGNATURE_DETAIL_COUNT = 4;
 
 /**
  * Compact formatter - optimized for token efficiency
- * Returns: path, type, name, score, optional snippet and imports
+ * Supports progressive disclosure to fit within token budgets
  */
 export class CompactFormatter implements ResultFormatter {
   private options: Required<FormatterOptions>;
@@ -25,38 +31,55 @@ export class CompactFormatter implements ResultFormatter {
       includePaths: options.includePaths ?? true,
       includeLineNumbers: options.includeLineNumbers ?? true,
       includeTypes: options.includeTypes ?? true,
-      includeSignatures: options.includeSignatures ?? false, // Compact mode excludes signatures
-      includeSnippets: options.includeSnippets ?? false, // Off by default for compact
-      includeImports: options.includeImports ?? false, // Off by default for compact
+      includeSignatures: options.includeSignatures ?? false,
+      includeSnippets: options.includeSnippets ?? false,
+      includeImports: options.includeImports ?? false,
       maxSnippetLines: options.maxSnippetLines ?? DEFAULT_MAX_SNIPPET_LINES,
-      tokenBudget: options.tokenBudget ?? 1000,
+      tokenBudget: options.tokenBudget ?? DEFAULT_TOKEN_BUDGET,
+      progressiveDisclosure: options.progressiveDisclosure ?? true,
+      fullDetailCount: options.fullDetailCount ?? DEFAULT_FULL_DETAIL_COUNT,
+      signatureDetailCount: options.signatureDetailCount ?? DEFAULT_SIGNATURE_DETAIL_COUNT,
     };
   }
 
   formatResult(result: SearchResult): string {
+    return this.formatResultWithDetail(result, 'full');
+  }
+
+  /**
+   * Format a result with a specific detail level
+   */
+  formatResultWithDetail(result: SearchResult, level: DetailLevel): string {
     const lines: string[] = [];
 
-    // Line 1: Header with score, type, name, path
+    // Always include header
     lines.push(this.formatHeader(result));
 
-    // Code snippet (if enabled)
-    if (this.options.includeSnippets && typeof result.metadata.snippet === 'string') {
-      const truncatedSnippet = this.truncateSnippet(
-        result.metadata.snippet,
-        this.options.maxSnippetLines
-      );
-      lines.push(this.indentText(truncatedSnippet, 3));
-    }
+    if (level === 'full') {
+      // Full detail: snippet + imports
+      if (this.options.includeSnippets && typeof result.metadata.snippet === 'string') {
+        const truncatedSnippet = this.truncateSnippet(
+          result.metadata.snippet,
+          this.options.maxSnippetLines
+        );
+        lines.push(this.indentText(truncatedSnippet, 3));
+      }
 
-    // Imports (if enabled)
-    if (this.options.includeImports && Array.isArray(result.metadata.imports)) {
-      const imports = result.metadata.imports as string[];
-      if (imports.length > 0) {
-        const displayImports = imports.slice(0, MAX_IMPORTS_DISPLAY);
-        const suffix = imports.length > MAX_IMPORTS_DISPLAY ? ' ...' : '';
-        lines.push(`   Imports: ${displayImports.join(', ')}${suffix}`);
+      if (this.options.includeImports && Array.isArray(result.metadata.imports)) {
+        const imports = result.metadata.imports as string[];
+        if (imports.length > 0) {
+          const displayImports = imports.slice(0, MAX_IMPORTS_DISPLAY);
+          const suffix = imports.length > MAX_IMPORTS_DISPLAY ? ' ...' : '';
+          lines.push(`   Imports: ${displayImports.join(', ')}${suffix}`);
+        }
+      }
+    } else if (level === 'signature') {
+      // Signature detail: just the signature
+      if (typeof result.metadata.signature === 'string') {
+        lines.push(`   ${result.metadata.signature}`);
       }
     }
+    // 'minimal' level = header only
 
     return lines.join('\n');
   }
@@ -64,20 +87,16 @@ export class CompactFormatter implements ResultFormatter {
   private formatHeader(result: SearchResult): string {
     const parts: string[] = [];
 
-    // Score
     parts.push(`[${(result.score * 100).toFixed(0)}%]`);
 
-    // Type
     if (this.options.includeTypes && typeof result.metadata.type === 'string') {
       parts.push(`${result.metadata.type}:`);
     }
 
-    // Name
     if (typeof result.metadata.name === 'string') {
       parts.push(result.metadata.name);
     }
 
-    // Path with line numbers
     if (this.options.includePaths && typeof result.metadata.path === 'string') {
       const pathPart =
         this.options.includeLineNumbers && typeof result.metadata.startLine === 'number'
@@ -107,8 +126,31 @@ export class CompactFormatter implements ResultFormatter {
       .join('\n');
   }
 
+  /**
+   * Determine detail level based on result position and remaining budget
+   */
+  private getDetailLevel(index: number, remainingBudget: number): DetailLevel {
+    if (!this.options.progressiveDisclosure) {
+      return 'full';
+    }
+
+    // Top N get full detail if budget allows
+    if (index < this.options.fullDetailCount && remainingBudget > 300) {
+      return 'full';
+    }
+
+    // Next M get signatures if budget allows
+    if (
+      index < this.options.fullDetailCount + this.options.signatureDetailCount &&
+      remainingBudget > 100
+    ) {
+      return 'signature';
+    }
+
+    return 'minimal';
+  }
+
   formatResults(results: SearchResult[]): FormattedResult {
-    // Handle empty results
     if (results.length === 0) {
       const content = 'No results found';
       return {
@@ -117,21 +159,43 @@ export class CompactFormatter implements ResultFormatter {
       };
     }
 
-    // Respect max results
     const limitedResults = results.slice(0, this.options.maxResults);
+    const budget = this.options.tokenBudget;
+    let usedTokens = 0;
+    const formatted: string[] = [];
+    let truncatedCount = 0;
 
-    // Format each result
-    const formatted = limitedResults.map((result, index) => {
-      return `${index + 1}. ${this.formatResult(result)}`;
-    });
+    for (let i = 0; i < limitedResults.length; i++) {
+      const result = limitedResults[i];
+      const remainingBudget = budget - usedTokens;
 
-    // Calculate total tokens (content only, no footer)
+      // Determine detail level
+      const detailLevel = this.getDetailLevel(i, remainingBudget);
+      const formattedResult = `${i + 1}. ${this.formatResultWithDetail(result, detailLevel)}`;
+      const tokens = estimateTokensForText(formattedResult);
+
+      // Check if we have budget (always include at least first result)
+      if (usedTokens + tokens > budget && i > 0) {
+        truncatedCount = limitedResults.length - i;
+        break;
+      }
+
+      formatted.push(formattedResult);
+      usedTokens += tokens;
+    }
+
+    // Add truncation notice if needed
+    if (truncatedCount > 0) {
+      const notice = `\n... ${truncatedCount} more results (token budget reached)`;
+      formatted.push(notice);
+      usedTokens += estimateTokensForText(notice);
+    }
+
     const content = formatted.join('\n');
-    const tokens = estimateTokensForText(content);
 
     return {
       content,
-      tokens,
+      tokens: usedTokens,
     };
   }
 
@@ -143,7 +207,6 @@ export class CompactFormatter implements ResultFormatter {
     }
 
     if (this.options.includeImports && Array.isArray(result.metadata.imports)) {
-      // ~3 tokens per import path
       estimate += (result.metadata.imports as string[]).length * 3;
     }
 

--- a/packages/mcp-server/src/formatters/types.ts
+++ b/packages/mcp-server/src/formatters/types.ts
@@ -39,6 +39,14 @@ export interface ResultFormatter {
 }
 
 /**
+ * Detail level for progressive disclosure
+ * - full: snippet + imports + signature
+ * - signature: signature only (no snippet)
+ * - minimal: name + path only
+ */
+export type DetailLevel = 'full' | 'signature' | 'minimal';
+
+/**
  * Formatter options
  */
 export interface FormatterOptions {
@@ -83,7 +91,24 @@ export interface FormatterOptions {
   maxSnippetLines?: number;
 
   /**
-   * Token budget (soft limit)
+   * Token budget (soft limit) - enables progressive disclosure when set
    */
   tokenBudget?: number;
+
+  /**
+   * Enable progressive disclosure based on token budget
+   * When enabled, top results get full detail, lower results get less
+   * (default: true when tokenBudget is set)
+   */
+  progressiveDisclosure?: boolean;
+
+  /**
+   * Number of top results to show with full detail (default: 3)
+   */
+  fullDetailCount?: number;
+
+  /**
+   * Number of results after fullDetailCount to show with signatures (default: 4)
+   */
+  signatureDetailCount?: number;
 }


### PR DESCRIPTION
## Summary

Implements #71 - Token budget management for search results (sub-issue 5/5 of Epic #66)

## Changes

### New Parameters
- Added `tokenBudget` parameter to `dev_search` tool (500-10000 tokens)
  - Compact mode default: 2000 tokens
  - Verbose mode default: 5000 tokens

### Progressive Disclosure Strategy
- **Full detail** (top 3 results): Complete snippet + imports + metadata
- **Signature detail** (next 4 results): Signature + metadata (no snippet body)
- **Minimal detail** (remaining): Header + location only
- Truncation notice when budget exceeded

### Formatter Options
Added to `FormatterOptions`:
- `progressiveDisclosure`: Enable/disable (default: true)
- `fullDetailCount`: Top N results with full detail (default: 3)
- `signatureDetailCount`: Next M results with signatures (default: 4)
- `DetailLevel` type: `'full' | 'signature' | 'minimal'`

### Token Estimation
Improved `estimateTokensForText()` with:
- `estimateCodeRatio()` for code-heavy text detection
- More accurate token estimation (3.5 chars/token for code vs 4 chars/token for prose)

## Testing
- 10 new tests for token budget management
- All 1292 tests passing

## Example Output

With budget of 2000 tokens and 10 results:
```
# Search Results (10 found, showing 7 within budget)

## 1. createPlan (function) - packages/subagents/src/planner/planner.ts
[Full snippet + imports + metadata]

## 2. handleMessage (method) - packages/subagents/src/planner/planner.ts
[Full snippet + imports + metadata]

## 3. PlannerAgent (class) - packages/subagents/src/planner/planner.ts
[Full snippet + imports + metadata]

## 4. breakdownTasks (function) - packages/subagents/src/planner/utils/breakdown.ts
[Signature only + metadata]

## 5. estimateEffort (function) - packages/subagents/src/planner/utils/estimation.ts
[Signature only + metadata]

...

---
*3 more results (token budget reached)*
```

Closes #71