### PR TITLE
feat(map): enhance dev_map with signatures, hot paths, and smart depth

### DIFF
--- a/packages/core/src/map/types.ts
+++ b/packages/core/src/map/types.ts
@@ -51,6 +51,10 @@ export interface MapOptions {
   includeHotPaths?: boolean;
   /** Maximum hot paths to show (default: 5) */
   maxHotPaths?: number;
+  /** Use smart depth - expand dense directories, collapse sparse ones (default: false) */
+  smartDepth?: boolean;
+  /** Minimum components to expand a directory when using smart depth (default: 10) */
+  smartDepthThreshold?: number;
   /** Token budget for output (default: 2000) */
   tokenBudget?: number;
 }


### PR DESCRIPTION
## Summary

Enhances the `dev_map` tool to provide richer, more useful codebase overviews for AI assistants.

## Changes

### 1. Signatures in Exports
- Export display now shows function/method signatures instead of just names
- Signatures truncated to 60 chars for readability
- Falls back to name if no signature available

### 2. Hot Paths (Most Referenced Files)
- New section showing files with most incoming references
- Computed from `callers` and `callees` metadata
- Helps AI identify central/important code quickly
- Configurable via `includeHotPaths` and `maxHotPaths` options

### 3. Smart Depth (Adaptive Expansion)
- Information density heuristic for tree pruning
- Expands directories with high component counts
- Collapses sparse directories to save tokens
- Always shows first 2 levels for basic structure
- Configurable via `smartDepth` and `smartDepthThreshold` options

## Example Output

```markdown
# Codebase Map

## Hot Paths (most referenced)
1. `packages/core/src/indexer/index.ts` (RepositoryIndexer) - 47 refs
2. `packages/core/src/vector/store.ts` (LanceDBVectorStore) - 32 refs
3. `packages/mcp-server/src/server/mcp-server.ts` (MCPServer) - 28 refs

## Directory Structure

└── packages/ (195 components)
    ├── core/ (45 components)
    │   └── exports: function search(query, opts): Promise<Result[]>, class RepositoryIndexer...
    ├── mcp-server/ (28 components)
    │   └── exports: class MCPServer, function createAdapter(config): Adapter...
```

## New Options

| Option | Type | Default | Description |
|--------|------|---------|-------------|
| `includeHotPaths` | boolean | true | Show hot paths section |
| `maxHotPaths` | number | 5 | Max hot paths to display |
| `smartDepth` | boolean | false | Use adaptive depth |
| `smartDepthThreshold` | number | 10 | Min components to expand |

## Testing
- 3 new tests for signatures
- 5 new tests for hot paths
- 3 new tests for smart depth
- All 1370 tests passing