### PR TITLE
feat(core): add change frequency to codebase map (#94)

### DIFF
--- a/packages/core/src/map/index.ts
+++ b/packages/core/src/map/index.ts
@@ -4,9 +4,17 @@
  */
 
 import * as path from 'node:path';
+import type { LocalGitExtractor } from '../git/extractor';
 import type { RepositoryIndexer } from '../indexer';
 import type { SearchResult } from '../vector/types';
-import type { CodebaseMap, ExportInfo, HotPath, MapNode, MapOptions } from './types';
+import type {
+  ChangeFrequency,
+  CodebaseMap,
+  ExportInfo,
+  HotPath,
+  MapNode,
+  MapOptions,
+} from './types';
 
 export * from './types';
 
@@ -21,7 +29,14 @@ const DEFAULT_OPTIONS: Required<MapOptions> = {
   smartDepth: false,
   smartDepthThreshold: 10,
   tokenBudget: 2000,
+  includeChangeFrequency: false,
 };
+
+/** Context for map generation including optional git extractor */
+export interface MapGenerationContext {
+  indexer: RepositoryIndexer;
+  gitExtractor?: LocalGitExtractor;
+}
 
 /**
  * Generate a codebase map from indexed documents
@@ -32,13 +47,36 @@ const DEFAULT_OPTIONS: Required<MapOptions> = {
  */
 export async function generateCodebaseMap(
   indexer: RepositoryIndexer,
-  options: MapOptions = {}
+  options?: MapOptions
+): Promise<CodebaseMap>;
+
+/**
+ * Generate a codebase map with git history context
+ *
+ * @param context - Map generation context with indexer and optional git extractor
+ * @param options - Map generation options
+ * @returns Codebase map structure
+ */
+export async function generateCodebaseMap(
+  context: MapGenerationContext,
+  options?: MapOptions
+): Promise<CodebaseMap>;
+
+export async function generateCodebaseMap(
+  indexerOrContext: RepositoryIndexer | MapGenerationContext,
+  options?: MapOptions
 ): Promise<CodebaseMap> {
-  const opts = { ...DEFAULT_OPTIONS, ...options };
+  const opts = { ...DEFAULT_OPTIONS, ...(options || {}) };
+
+  // Normalize input
+  const context: MapGenerationContext =
+    'indexer' in indexerOrContext
+      ? indexerOrContext
+      : { indexer: indexerOrContext as RepositoryIndexer };
 
   // Get all indexed documents (use a broad search)
   // Note: We search with a generic query to get all documents
-  const allDocs = await indexer.search('function class interface type', {
+  const allDocs = await context.indexer.search('function class interface type', {
     limit: 10000,
     scoreThreshold: 0,
   });
@@ -52,6 +90,11 @@ export async function generateCodebaseMap(
 
   // Compute hot paths (most referenced files)
   const hotPaths = opts.includeHotPaths ? computeHotPaths(allDocs, opts.maxHotPaths) : [];
+
+  // Compute change frequency if requested and git extractor is available
+  if (opts.includeChangeFrequency && context.gitExtractor) {
+    await computeChangeFrequency(root, context.gitExtractor);
+  }
 
   return {
     root,
@@ -275,6 +318,86 @@ function countDirectories(node: MapNode): number {
 }
 
 /**
+ * Compute change frequency for all nodes in the tree
+ */
+async function computeChangeFrequency(root: MapNode, extractor: LocalGitExtractor): Promise<void> {
+  // Collect all unique directory paths
+  const dirPaths = collectDirectoryPaths(root);
+
+  // Get date thresholds
+  const now = new Date();
+  const thirtyDaysAgo = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000);
+  const ninetyDaysAgo = new Date(now.getTime() - 90 * 24 * 60 * 60 * 1000);
+
+  // Compute frequency for each directory
+  const frequencyMap = new Map<string, ChangeFrequency>();
+
+  for (const dirPath of dirPaths) {
+    try {
+      // Get commits for this directory in the last 90 days
+      const commits = await extractor.getCommits({
+        path: dirPath === 'root' ? '.' : dirPath,
+        limit: 100,
+        since: ninetyDaysAgo.toISOString(),
+        noMerges: true,
+      });
+
+      // Count commits in each time window
+      let last30Days = 0;
+      const last90Days = commits.length;
+      let lastCommit: string | undefined;
+
+      for (const commit of commits) {
+        const commitDate = new Date(commit.author.date);
+        if (commitDate >= thirtyDaysAgo) {
+          last30Days++;
+        }
+        if (!lastCommit || commitDate > new Date(lastCommit)) {
+          lastCommit = commit.author.date;
+        }
+      }
+
+      frequencyMap.set(dirPath, {
+        last30Days,
+        last90Days,
+        lastCommit,
+      });
+    } catch {
+      // Directory might not exist in git or other error
+      // Just skip it
+    }
+  }
+
+  // Apply frequency data to tree nodes
+  applyChangeFrequency(root, frequencyMap);
+}
+
+/**
+ * Collect all directory paths from the tree
+ */
+function collectDirectoryPaths(node: MapNode, paths: string[] = []): string[] {
+  paths.push(node.path);
+  for (const child of node.children) {
+    collectDirectoryPaths(child, paths);
+  }
+  return paths;
+}
+
+/**
+ * Apply change frequency data to tree nodes
+ */
+function applyChangeFrequency(node: MapNode, frequencyMap: Map<string, ChangeFrequency>): void {
+  const freq = frequencyMap.get(node.path);
+  if (freq) {
+    node.changeFrequency = freq;
+  }
+
+  for (const child of node.children) {
+    applyChangeFrequency(child, frequencyMap);
+  }
+}
+
+/**
  * Compute hot paths - files with the most incoming references
  */
 function computeHotPaths(docs: SearchResult[], maxPaths: number): HotPath[] {
@@ -369,7 +492,23 @@ function formatNode(
   const connector = isLast ? '└── ' : '├── ';
   const countStr = node.componentCount > 0 ? ` (${node.componentCount} components)` : '';
 
-  lines.push(`${prefix}${connector}${node.name}/${countStr}`);
+  // Add change frequency indicator if available
+  let freqStr = '';
+  if (opts.includeChangeFrequency && node.changeFrequency) {
+    const freq = node.changeFrequency;
+    if (freq.last30Days > 0) {
+      // Hot: 5+ commits in 30 days
+      if (freq.last30Days >= 5) {
+        freqStr = ` 🔥 ${freq.last30Days} commits this month`;
+      } else {
+        freqStr = ` ✏️ ${freq.last30Days} commits this month`;
+      }
+    } else if (freq.last90Days > 0) {
+      freqStr = ` 📝 ${freq.last90Days} commits (90d)`;
+    }
+  }
+
+  lines.push(`${prefix}${connector}${node.name}/${countStr}${freqStr}`);
 
   // Add exports if present
   if (opts.includeExports && node.exports && node.exports.length > 0) {

--- a/packages/core/src/map/types.ts
+++ b/packages/core/src/map/types.ts
@@ -4,6 +4,18 @@
  */
 
 /**
+ * Change frequency data for a node
+ */
+export interface ChangeFrequency {
+  /** Number of commits in the last 30 days */
+  last30Days: number;
+  /** Number of commits in the last 90 days */
+  last90Days: number;
+  /** Date of the most recent commit */
+  lastCommit?: string;
+}
+
+/**
  * A node in the codebase map tree
  */
 export interface MapNode {
@@ -19,6 +31,8 @@ export interface MapNode {
   exports?: ExportInfo[];
   /** Whether this is a leaf node (file, not directory) */
   isFile?: boolean;
+  /** Change frequency data (if includeChangeFrequency is true) */
+  changeFrequency?: ChangeFrequency;
 }
 
 /**
@@ -57,6 +71,8 @@ export interface MapOptions {
   smartDepthThreshold?: number;
   /** Token budget for output (default: 2000) */
   tokenBudget?: number;
+  /** Include change frequency data (default: false) */
+  includeChangeFrequency?: boolean;
 }
 
 /**

--- a/packages/mcp-server/bin/dev-agent-mcp.ts
+++ b/packages/mcp-server/bin/dev-agent-mcp.ts
@@ -193,6 +193,7 @@ async function main() {
 
     const mapAdapter = new MapAdapter({
       repositoryIndexer: indexer,
+      repositoryPath,
       defaultDepth: 2,
       defaultTokenBudget: 2000,
     });


### PR DESCRIPTION
## Summary

Adds change frequency data to the codebase map, showing how often directories are modified. This helps identify "hot" areas of the codebase.

## Changes

### Types (`packages/core/src/map/types.ts`)
- Added `ChangeFrequency` interface with:
  - `last30Days`: Commits in the last 30 days
  - `last90Days`: Commits in the last 90 days
  - `lastCommit`: Date of most recent commit
- Added `includeChangeFrequency` option to `MapOptions`
- Added `changeFrequency` field to `MapNode`

### Core (`packages/core/src/map/index.ts`)
- Added `MapGenerationContext` interface for flexible input
- Implemented `computeChangeFrequency()` function:
  - Collects all directory paths from tree
  - Queries git for commits in each directory (last 90 days)
  - Counts commits in 30-day and 90-day windows
  - Applies data to tree nodes
- Updated `formatCodebaseMap()` to display frequency indicators:
  - 🔥 5+ commits this month (hot)
  - ✏️ 1-4 commits this month (active)
  - 📝 commits in last 90 days

### Adapter (`packages/mcp-server/src/adapters/built-in/map-adapter.ts`)
- Added `repositoryPath` config option
- Added `includeChangeFrequency` parameter to tool schema
- Creates `LocalGitExtractor` when change frequency is requested
- Passes context to `generateCodebaseMap()`

### Tests
- Added 3 tests for change frequency feature:
  - Include frequency when enabled
  - Skip frequency when disabled
  - Format frequency in output

## Example Output

```
├── packages/ (500 components) 🔥 12 commits this month
│   ├── core/ (200 components) ✏️ 3 commits this month
│   ├── mcp-server/ (150 components) 🔥 8 commits this month
│   └── cli/ (50 components) 📝 5 commits (90d)
```

## Closes

Closes #94

## Part of

Epic: Intelligent Git History (v0.4.0) #90