### PR TITLE
fix(mcp): remove anyOf from dev_history schema for Claude API compatibility

### DIFF
--- a/.changeset/fix-history-adapter-schema.md
+++ b/.changeset/fix-history-adapter-schema.md
@@ -1,0 +1,10 @@
+---
+"@lytics/dev-agent": patch
+"@lytics/dev-agent-mcp": patch
+---
+
+Fix dev_history tool schema for Claude API compatibility
+
+- Removed `anyOf` from input schema (Claude API doesn't support it at top level)
+- Validation for "at least one of query or file required" is still enforced in execute()
+

--- a/packages/mcp-server/src/adapters/__tests__/history-adapter.test.ts
+++ b/packages/mcp-server/src/adapters/__tests__/history-adapter.test.ts
@@ -97,10 +97,8 @@ describe('HistoryAdapter', () => {
     it('should require either query or file', () => {
       const definition = adapter.getToolDefinition();
 
-      expect(definition.inputSchema.anyOf).toEqual([
-        { required: ['query'] },
-        { required: ['file'] },
-      ]);
+      // Note: anyOf removed for Claude API compatibility - validation is done in execute()
+      expect(definition.inputSchema.required).toEqual([]);
     });
   });
 

--- a/packages/mcp-server/src/adapters/built-in/history-adapter.ts
+++ b/packages/mcp-server/src/adapters/built-in/history-adapter.ts
@@ -110,8 +110,8 @@ export class HistoryAdapter extends ToolAdapter {
             default: this.config.defaultTokenBudget,
           },
         },
-        // At least one of query or file is required
-        anyOf: [{ required: ['query'] }, { required: ['file'] }],
+        // Note: At least one of query or file is required (validated in execute)
+        required: [],
       },
     };
   }


### PR DESCRIPTION
## Problem

Claude's API returns error 400:
```
input_schema does not support oneOf, allOf, or anyOf at the top level
```

## Solution

- Removed `anyOf` from `dev_history` input schema
- Validation for "at least one of query or file required" is still enforced in `execute()` method

## Testing
- All 1441 tests pass
- Tested MCP server locally - all 9 tools register correctly