### PR TITLE
docs: update roadmap and AI agent guidance files

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -179,10 +179,13 @@ Specialized agents for development tasks.
 
 MCP server with built-in adapters for AI tools.
 
-**Adapters:**
+**Adapters (9 tools):**
 - **SearchAdapter:** Semantic code search (`dev_search`)
+- **RefsAdapter:** Relationship queries - callers/callees (`dev_refs`)
+- **MapAdapter:** Codebase structure with change frequency (`dev_map`)
+- **HistoryAdapter:** Semantic git commit search (`dev_history`)
 - **StatusAdapter:** Repository status (`dev_status`)
-- **PlanAdapter:** Planning from issues (`dev_plan`)
+- **PlanAdapter:** Context assembly for issues (`dev_plan`)
 - **ExploreAdapter:** Code exploration (`dev_explore`)
 - **GitHubAdapter:** Issue/PR search (`dev_gh`)
 - **HealthAdapter:** Server health checks (`dev_health`)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -154,16 +154,19 @@ dev mcp install
 
 That's it! Claude Code now has access to all dev-agent capabilities.
 
-### Available Tools in Claude Code & Cursor
+### Available Tools in Claude Code & Cursor (9 tools)
 
-Once installed, AI tools gain access to these powerful capabilities:
+Once installed, AI tools gain access to:
 
-- **`dev_search`** - Semantic code search across indexed repositories
-- **`dev_status`** - Repository indexing status and health information  
-- **`dev_plan`** - Generate implementation plans from GitHub issues
-- **`dev_explore`** - Explore code patterns, find similar code, analyze relationships
-- **`dev_gh`** - Search GitHub issues and pull requests with semantic context (auto-reloads on index changes)
-- **`dev_health`** - Check MCP server health and component status (vector storage, repository, GitHub index)
+- **`dev_search`** - Semantic code search (USE THIS FIRST for conceptual queries)
+- **`dev_refs`** - Find callers/callees of functions (for specific symbols)
+- **`dev_map`** - Codebase structure with component counts and change frequency
+- **`dev_history`** - Semantic search over git commits (who changed what and why)
+- **`dev_plan`** - Assemble context for GitHub issues (code + history + patterns)
+- **`dev_explore`** - Find similar code, trace relationships
+- **`dev_gh`** - Search GitHub issues/PRs semantically
+- **`dev_status`** - Repository indexing status
+- **`dev_health`** - Server health checks
 
 ### MCP Command Reference
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -213,7 +213,7 @@ Git history is valuable context that LLMs can't easily access. We add intelligen
 
 > Building on git history with deeper insights.
 
-### Tasks
+### Git Tasks
 
 | Task | Priority | Status |
 |------|----------|--------|
@@ -221,6 +221,28 @@ Git history is valuable context that LLMs can't easily access. We add intelligen
 | PR/issue linking from commits | 🟡 Medium | 🔲 Todo |
 | Contributor expertise mapping | 🟢 Low | 🔲 Todo |
 | Cross-repo history | 🟢 Low | 🔲 Todo |
+
+### Tool Improvements
+
+| Task | Rationale | Priority | Status |
+|------|-----------|----------|--------|
+| Generalize `dev_plan` → `dev_context` | Currently requires GitHub issue; should work with any task description | 🔴 High | 🔲 Todo |
+| Freeform context assembly | `dev_context "Add rate limiting"` without needing issue # | 🔴 High | 🔲 Todo |
+| Multiple input modes | `--issue 42`, `--file src/auth.ts`, or freeform query | 🟡 Medium | 🔲 Todo |
+
+**Why:** `dev_plan` is really a context assembler but is tightly coupled to GitHub issues. Generalizing it:
+- Works without GitHub
+- Easier to benchmark (no real issues needed)
+- Name matches function (assembles context, doesn't "plan")
+- More useful for ad-hoc implementation tasks
+
+### Benchmark Improvements
+
+| Task | Rationale | Priority | Status |
+|------|-----------|----------|--------|
+| Add implementation task types | Current benchmark only tests exploration; missing `dev_plan`/`dev_gh` coverage | 🟡 Medium | 🔲 Todo |
+| Generic implementation patterns | "Add a new adapter similar to X" — tests pattern discovery | 🟡 Medium | 🔲 Todo |
+| Snapshotted issue tests | Capture real issues for reproducible `dev_plan` testing | 🟢 Low | 🔲 Todo |
 
 ---
 
@@ -347,4 +369,4 @@ pnpm test
 
 ---
 
-*Last updated: November 2025*
+*Last updated: November 29, 2025 at 01:42 PST*


### PR DESCRIPTION
## Summary

Documentation refresh to reflect current state and plan v0.5.0.

## Changes

### PLAN.md
- Added v0.5.0 roadmap with `dev_context` generalization (decouple from GitHub issues)
- Added benchmark improvements for implementation task coverage
- Updated timestamp

### AGENTS.md & CLAUDE.md
- Updated to show all **9 MCP tools** (was missing `dev_refs`, `dev_map`, `dev_history`)
- Improved tool descriptions to match v0.4.2 updates

## Why

1. **AI agent files were outdated** — Still showed 6 tools instead of 9
2. **v0.5.0 planning** — Captured discussion about generalizing `dev_plan` → `dev_context`
3. **Benchmark gaps** — Documented need for implementation task benchmarks