### PR TITLE
feat(mcp): add test file hints to dev_search results

### DIFF
--- a/.changeset/test-file-hints.md
+++ b/.changeset/test-file-hints.md
@@ -1,0 +1,15 @@
+---
+"@lytics/dev-agent-mcp": patch
+"@lytics/dev-agent": patch
+---
+
+### Features
+
+- **Test file hints in search results**: `dev_search` now shows related test files (e.g., `utils.test.ts`) after search results. This surfaces test files without polluting semantic search rankings.
+
+### Design
+
+- Uses structural matching (`.test.ts`, `.spec.ts` patterns) rather than semantic search
+- Keeps semantic search pure - test hints are in a separate "Related test files:" section
+- Patterns are configurable for future extensibility via function parameters
+

--- a/packages/mcp-server/bin/dev-agent-mcp.ts
+++ b/packages/mcp-server/bin/dev-agent-mcp.ts
@@ -145,6 +145,7 @@ async function main() {
     // Create and register adapters
     const searchAdapter = new SearchAdapter({
       repositoryIndexer: indexer,
+      repositoryPath,
       defaultFormat: 'compact',
       defaultLimit: 10,
     });

--- a/packages/mcp-server/src/adapters/types.ts
+++ b/packages/mcp-server/src/adapters/types.ts
@@ -65,6 +65,10 @@ export interface MCPMetadata {
   results_returned?: number;
   /** Whether results were truncated due to limits */
   results_truncated?: boolean;
+
+  // Related files (optional)
+  /** Number of related test files found */
+  related_files_count?: number;
 }
 
 // Tool Result

--- a/packages/mcp-server/src/formatters/__tests__/utils.test.ts
+++ b/packages/mcp-server/src/formatters/__tests__/utils.test.ts
@@ -208,11 +208,11 @@ describe('Formatter Utils', () => {
     it('should return elapsed time', async () => {
       const timer = startTimer();
 
-      // Wait a bit
-      await new Promise((resolve) => setTimeout(resolve, 10));
+      // Wait a bit (use 15ms to avoid flaky timing issues)
+      await new Promise((resolve) => setTimeout(resolve, 15));
 
       const elapsed = timer.elapsed();
-      expect(elapsed).toBeGreaterThanOrEqual(10);
+      expect(elapsed).toBeGreaterThanOrEqual(10); // Allow some timing variance
       expect(elapsed).toBeLessThan(100); // Should be fast
     });
 

--- a/packages/mcp-server/src/utils/__tests__/related-files.test.ts
+++ b/packages/mcp-server/src/utils/__tests__/related-files.test.ts
@@ -1,0 +1,192 @@
+/**
+ * Tests for Related Files Utility
+ */
+
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  DEFAULT_TEST_PATTERNS,
+  findRelatedTestFiles,
+  findTestFile,
+  formatRelatedFiles,
+  type RelatedFile,
+  type TestPatternFn,
+} from '../related-files';
+
+describe('Related Files Utility', () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'related-files-test-'));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  describe('findTestFile', () => {
+    it('should find .test.ts sibling', async () => {
+      // Create source and test files
+      await fs.writeFile(path.join(tempDir, 'utils.ts'), 'export const x = 1;');
+      await fs.writeFile(path.join(tempDir, 'utils.test.ts'), 'test("x", () => {});');
+
+      const result = await findTestFile('utils.ts', tempDir);
+
+      expect(result).not.toBeNull();
+      expect(result?.relatedPath).toBe('utils.test.ts');
+      expect(result?.type).toBe('test');
+    });
+
+    it('should find .spec.ts sibling', async () => {
+      await fs.writeFile(path.join(tempDir, 'utils.ts'), 'export const x = 1;');
+      await fs.writeFile(path.join(tempDir, 'utils.spec.ts'), 'test("x", () => {});');
+
+      const result = await findTestFile('utils.ts', tempDir);
+
+      expect(result).not.toBeNull();
+      expect(result?.relatedPath).toBe('utils.spec.ts');
+      expect(result?.type).toBe('spec');
+    });
+
+    it('should return null for files without tests', async () => {
+      await fs.writeFile(path.join(tempDir, 'utils.ts'), 'export const x = 1;');
+
+      const result = await findTestFile('utils.ts', tempDir);
+
+      expect(result).toBeNull();
+    });
+
+    it('should return null for test files (skip self)', async () => {
+      await fs.writeFile(path.join(tempDir, 'utils.test.ts'), 'test("x", () => {});');
+
+      const result = await findTestFile('utils.test.ts', tempDir);
+
+      expect(result).toBeNull();
+    });
+
+    it('should return null for spec files (skip self)', async () => {
+      await fs.writeFile(path.join(tempDir, 'utils.spec.ts'), 'test("x", () => {});');
+
+      const result = await findTestFile('utils.spec.ts', tempDir);
+
+      expect(result).toBeNull();
+    });
+
+    it('should handle nested directories', async () => {
+      await fs.mkdir(path.join(tempDir, 'src', 'utils'), { recursive: true });
+      await fs.writeFile(path.join(tempDir, 'src', 'utils', 'helper.ts'), 'export const x = 1;');
+      await fs.writeFile(
+        path.join(tempDir, 'src', 'utils', 'helper.test.ts'),
+        'test("x", () => {});'
+      );
+
+      const result = await findTestFile('src/utils/helper.ts', tempDir);
+
+      expect(result).not.toBeNull();
+      expect(result?.relatedPath).toBe('src/utils/helper.test.ts');
+    });
+  });
+
+  describe('findRelatedTestFiles', () => {
+    it('should find test files for multiple sources', async () => {
+      await fs.writeFile(path.join(tempDir, 'a.ts'), 'export const a = 1;');
+      await fs.writeFile(path.join(tempDir, 'a.test.ts'), 'test("a", () => {});');
+      await fs.writeFile(path.join(tempDir, 'b.ts'), 'export const b = 1;');
+      await fs.writeFile(path.join(tempDir, 'b.test.ts'), 'test("b", () => {});');
+      await fs.writeFile(path.join(tempDir, 'c.ts'), 'export const c = 1;');
+      // No test for c.ts
+
+      const results = await findRelatedTestFiles(['a.ts', 'b.ts', 'c.ts'], tempDir);
+
+      expect(results).toHaveLength(2);
+      expect(results.map((r) => r.relatedPath).sort()).toEqual(['a.test.ts', 'b.test.ts']);
+    });
+
+    it('should deduplicate source paths', async () => {
+      await fs.writeFile(path.join(tempDir, 'utils.ts'), 'export const x = 1;');
+      await fs.writeFile(path.join(tempDir, 'utils.test.ts'), 'test("x", () => {});');
+
+      const results = await findRelatedTestFiles(['utils.ts', 'utils.ts', 'utils.ts'], tempDir);
+
+      expect(results).toHaveLength(1);
+    });
+
+    it('should return empty array when no tests found', async () => {
+      await fs.writeFile(path.join(tempDir, 'a.ts'), 'export const a = 1;');
+      await fs.writeFile(path.join(tempDir, 'b.ts'), 'export const b = 1;');
+
+      const results = await findRelatedTestFiles(['a.ts', 'b.ts'], tempDir);
+
+      expect(results).toEqual([]);
+    });
+
+    it('should return empty array for empty input', async () => {
+      const results = await findRelatedTestFiles([], tempDir);
+
+      expect(results).toEqual([]);
+    });
+  });
+
+  describe('formatRelatedFiles', () => {
+    it('should format related files as string', () => {
+      const files: RelatedFile[] = [
+        { sourcePath: 'utils.ts', relatedPath: 'utils.test.ts', type: 'test' },
+        { sourcePath: 'helper.ts', relatedPath: 'helper.spec.ts', type: 'spec' },
+      ];
+
+      const result = formatRelatedFiles(files);
+
+      expect(result).toContain('Related test files:');
+      expect(result).toContain('utils.test.ts');
+      expect(result).toContain('helper.spec.ts');
+    });
+
+    it('should return empty string for empty array', () => {
+      const result = formatRelatedFiles([]);
+
+      expect(result).toBe('');
+    });
+
+    it('should include separator line', () => {
+      const files: RelatedFile[] = [
+        { sourcePath: 'utils.ts', relatedPath: 'utils.test.ts', type: 'test' },
+      ];
+
+      const result = formatRelatedFiles(files);
+
+      expect(result).toContain('---');
+    });
+  });
+
+  describe('custom patterns', () => {
+    it('should support custom test patterns', async () => {
+      // Create a custom pattern for __tests__ directory
+      const customPatterns: TestPatternFn[] = [
+        ...DEFAULT_TEST_PATTERNS,
+        (base, ext, dir) => path.join(dir, '__tests__', `${path.basename(base)}${ext}`),
+      ];
+
+      await fs.mkdir(path.join(tempDir, '__tests__'));
+      await fs.writeFile(path.join(tempDir, 'utils.ts'), 'export const x = 1;');
+      await fs.writeFile(path.join(tempDir, '__tests__', 'utils.ts'), 'test("x", () => {});');
+
+      const result = await findTestFile('utils.ts', tempDir, customPatterns);
+
+      expect(result).not.toBeNull();
+      expect(result?.relatedPath).toBe('__tests__/utils.ts');
+    });
+
+    it('should use default patterns when none provided', async () => {
+      await fs.writeFile(path.join(tempDir, 'utils.ts'), 'export const x = 1;');
+      await fs.writeFile(path.join(tempDir, 'utils.test.ts'), 'test("x", () => {});');
+
+      // Call without patterns parameter - should use defaults
+      const result = await findTestFile('utils.ts', tempDir);
+
+      expect(result).not.toBeNull();
+      expect(result?.relatedPath).toBe('utils.test.ts');
+    });
+  });
+});

--- a/packages/mcp-server/src/utils/related-files.ts
+++ b/packages/mcp-server/src/utils/related-files.ts
@@ -1,0 +1,154 @@
+/**
+ * Related Files Utility
+ * Finds structurally related files (test files, type files, etc.)
+ *
+ * Design: Accepts patterns as parameters for future configurability.
+ * Currently uses simple heuristics (*.test.*, *.spec.*) that match
+ * common conventions across Jest, Vitest, Mocha, etc.
+ */
+
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+
+/**
+ * Related file information
+ */
+export interface RelatedFile {
+  /** Path to the source file */
+  sourcePath: string;
+  /** Path to the related file */
+  relatedPath: string;
+  /** Type of relationship */
+  type: 'test' | 'spec' | 'types' | 'index';
+}
+
+/**
+ * Pattern function type for generating test file paths
+ */
+export type TestPatternFn = (base: string, ext: string, dir: string) => string;
+
+/**
+ * Default test file patterns (covers most JS/TS projects)
+ * - foo.ts -> foo.test.ts
+ * - foo.ts -> foo.spec.ts
+ *
+ * Note: Can be extended via config in future versions to support
+ * project-specific patterns like __tests__/, tests/, etc.
+ */
+export const DEFAULT_TEST_PATTERNS: TestPatternFn[] = [
+  // Same directory: foo.ts -> foo.test.ts, foo.spec.ts
+  (base: string, ext: string) => `${base}.test${ext}`,
+  (base: string, ext: string) => `${base}.spec${ext}`,
+];
+
+/**
+ * Check if a file exists
+ */
+async function fileExists(filePath: string): Promise<boolean> {
+  try {
+    await fs.access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Check if a path looks like a test file
+ */
+function isTestFile(filePath: string): boolean {
+  return filePath.includes('.test.') || filePath.includes('.spec.');
+}
+
+/**
+ * Find test file for a given source file
+ *
+ * @param sourcePath - Path to the source file (relative to repository)
+ * @param repositoryPath - Root path of the repository
+ * @param patterns - Test file patterns to check (defaults to DEFAULT_TEST_PATTERNS)
+ * @returns Related test file if found, null otherwise
+ */
+export async function findTestFile(
+  sourcePath: string,
+  repositoryPath: string,
+  patterns: TestPatternFn[] = DEFAULT_TEST_PATTERNS
+): Promise<RelatedFile | null> {
+  // Skip if already a test file
+  if (isTestFile(sourcePath)) {
+    return null;
+  }
+
+  const ext = path.extname(sourcePath);
+  const base = sourcePath.slice(0, -ext.length);
+  const dir = path.dirname(sourcePath);
+  const fullDir = path.join(repositoryPath, dir);
+
+  for (const pattern of patterns) {
+    const testPath = pattern(base, ext, fullDir);
+    const fullTestPath = testPath.startsWith(repositoryPath)
+      ? testPath
+      : path.join(repositoryPath, testPath);
+
+    if (await fileExists(fullTestPath)) {
+      // Return relative path
+      const relatedPath = path.relative(repositoryPath, fullTestPath);
+      const type = relatedPath.includes('.spec.') ? 'spec' : 'test';
+      return {
+        sourcePath,
+        relatedPath,
+        type,
+      };
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Find related test files for multiple source files
+ *
+ * @param sourcePaths - Array of source file paths (relative to repository)
+ * @param repositoryPath - Root path of the repository
+ * @param patterns - Test file patterns to check (defaults to DEFAULT_TEST_PATTERNS)
+ * @returns Array of related files found
+ */
+export async function findRelatedTestFiles(
+  sourcePaths: string[],
+  repositoryPath: string,
+  patterns: TestPatternFn[] = DEFAULT_TEST_PATTERNS
+): Promise<RelatedFile[]> {
+  // Deduplicate source paths
+  const uniquePaths = [...new Set(sourcePaths)];
+
+  const results = await Promise.all(
+    uniquePaths.map((sourcePath) => findTestFile(sourcePath, repositoryPath, patterns))
+  );
+
+  // Filter out nulls and deduplicate by relatedPath
+  const seen = new Set<string>();
+  return results.filter((result): result is RelatedFile => {
+    if (result === null) return false;
+    if (seen.has(result.relatedPath)) return false;
+    seen.add(result.relatedPath);
+    return true;
+  });
+}
+
+/**
+ * Format related files as a string for output
+ *
+ * @param relatedFiles - Array of related files
+ * @returns Formatted string
+ */
+export function formatRelatedFiles(relatedFiles: RelatedFile[]): string {
+  if (relatedFiles.length === 0) {
+    return '';
+  }
+
+  const lines = ['', '---', 'Related test files:'];
+  for (const file of relatedFiles) {
+    lines.push(`  • ${file.relatedPath}`);
+  }
+
+  return lines.join('\n');
+}


### PR DESCRIPTION
## Summary

Closes the benchmark gap: "Baseline read test files; dev-agent skipped them"

After semantic search results, `dev_search` now shows related test files in a separate section:

```
1. [89%] function: authenticate (src/auth.ts:15)
2. [84%] class: AuthMiddleware (src/middleware.ts:5)

---
Related test files:
  • src/auth.test.ts
  • src/middleware.test.ts
```

## Design Decisions

| Decision | Rationale |
|----------|-----------|
| Structural matching (`.test.ts`, `.spec.ts`) | Test files have structural relationship, not semantic |
| Separate section | Keeps semantic search rankings pure |
| Parameterized patterns | Future configurability without refactoring |

## Implementation

- New `related-files.ts` utility with `findTestFile`, `findRelatedTestFiles`
- `SearchAdapter` calls utility after formatting results
- `MCPMetadata` extended with `related_files_count` field
- Patterns exportable for custom configurations

## Testing

- 15 new tests for utility functions
- All 1472 existing tests pass