### PR TITLE
docs: update for Go language support (v0.6.0)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,12 +16,15 @@ This file provides guidance to AI agents (Claude, Cursor, etc.) when working wit
 - Package Manager: pnpm 8.15.4
 - Build System: Turborepo  
 - Linter/Formatter: Biome
-- Testing: Vitest (1100+ tests)
+- Testing: Vitest (1500+ tests)
 - Vector Storage: LanceDB
 - Embeddings: @xenova/transformers (all-MiniLM-L6-v2)
+- Parsers: ts-morph (TypeScript/JS), tree-sitter WASM (Go)
 - AI Integration: MCP (Model Context Protocol)
 - CI/CD: GitHub Actions
 - Node.js: >= 22 (LTS)
+
+**Supported Languages:** TypeScript, JavaScript, Go, Markdown
 
 ## Repository Structure
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,20 +62,23 @@ pnpm -F "@lytics/dev-agent-core" dev
 - **packages/mcp-server**: MCP (Model Context Protocol) server implementation
 
 ### Key Technologies
-- TypeScript Compiler API & ts-morph for repository analysis
+- TypeScript Compiler API & ts-morph for TypeScript/JS analysis
+- tree-sitter WASM for Go analysis (extensible to Python/Rust)
 - LanceDB for vector storage (replaced Chroma DB for better performance)
 - @xenova/transformers for local embeddings (all-MiniLM-L6-v2)
 - remark for Markdown parsing
 - GitHub CLI for metadata integration
 - Turborepo for build orchestration
 - Biome for linting/formatting
-- Vitest for testing (1100+ tests)
+- Vitest for testing (1500+ tests)
 - MCP (Model Context Protocol) for AI tool integration
 - Token Bucket algorithm for rate limiting
 - Exponential backoff for retry logic
 
+**Supported Languages:** TypeScript, JavaScript, Go, Markdown
+
 ### Core Components
-- **Scanner**: Uses TypeScript Compiler API and ts-morph to extract components and relationships
+- **Scanner**: Uses ts-morph (TS/JS) and tree-sitter (Go) to extract components and relationships
 - **Vector Storage**: Semantic search with LanceDB and @xenova/transformers embeddings
 - **GitHub Integration**: Metadata extraction and semantic search for issues/PRs using GitHub CLI
 - **Subagent System**: Specialized agents for planning, exploration, and PR management

--- a/README.md
+++ b/README.md
@@ -262,15 +262,24 @@ dev-agent/
 └── website/            # Documentation website
 ```
 
+## Supported Languages
+
+| Language | Scanner | Features |
+|----------|---------|----------|
+| **TypeScript/JavaScript** | ts-morph | Functions, classes, interfaces, JSDoc |
+| **Go** | tree-sitter | Functions, methods, structs, interfaces, generics |
+| **Markdown** | remark | Documentation sections, code blocks |
+
 ## Technology Stack
 
 - **TypeScript** (strict mode)
-- **ts-morph** / TypeScript Compiler API (AST analysis)
+- **ts-morph** / TypeScript Compiler API (TypeScript/JS analysis)
+- **tree-sitter** WASM (Go analysis, extensible to Python/Rust)
 - **LanceDB** (embedded vector storage)
 - **@xenova/transformers** (local embeddings)
 - **MCP** (Model Context Protocol)
 - **Turborepo** (monorepo builds)
-- **Vitest** (1300+ tests)
+- **Vitest** (1500+ tests)
 
 ## Development
 
@@ -294,6 +303,11 @@ pnpm typecheck
 
 ## Version History
 
+- **v0.6.0** - Go Language Support
+  - Go scanner with tree-sitter WASM (functions, methods, structs, interfaces, generics)
+  - Indexer logging with `--verbose` flag and progress spinners
+  - Go-specific exclusions (*.pb.go, *.gen.go, mocks/, testdata/)
+  - Infrastructure for future Python/Rust support
 - **v0.4.0** - Intelligent Git History release
   - New `dev_history` tool for semantic commit search
   - Enhanced `dev_map` with change frequency indicators (🔥 hot, ✏️ active)

--- a/website/content/docs/architecture.mdx
+++ b/website/content/docs/architecture.mdx
@@ -48,7 +48,10 @@ dev-agent is built as a TypeScript monorepo with specialized packages for differ
 
 The foundation layer providing:
 
-- **Scanner** — Multi-language AST parsing using TypeScript Compiler API and ts-morph
+- **Scanner** — Multi-language AST parsing:
+  - TypeScript/JavaScript via ts-morph
+  - Go via tree-sitter WASM
+  - Markdown via remark
 - **Indexer** — Converts code components to vector embeddings
 - **Vector Storage** — LanceDB for fast similarity search
 - **GitHub Integration** — Fetches and indexes issues/PRs via GitHub CLI
@@ -91,18 +94,28 @@ Centralized logging:
 - JSON and pretty formatters
 - Structured metadata
 
+## Supported Languages
+
+| Language | Scanner | Features |
+|----------|---------|----------|
+| TypeScript/JavaScript | ts-morph | Functions, classes, interfaces, JSDoc |
+| Go | tree-sitter WASM | Functions, methods, structs, interfaces, generics |
+| Markdown | remark | Documentation sections, code blocks |
+
 ## Key Technologies
 
 | Component | Technology | Purpose |
 |-----------|------------|---------|
 | Language | TypeScript (strict) | Type safety |
 | Build | Turborepo | Monorepo orchestration |
-| Testing | Vitest | 1100+ tests |
+| Testing | Vitest | 1500+ tests |
 | Linting | Biome | Fast linting/formatting |
 | Vector DB | LanceDB | Embedded vector storage |
 | Embeddings | @xenova/transformers | Local ML inference |
 | Model | all-MiniLM-L6-v2 | Sentence embeddings |
 | Protocol | MCP | AI tool integration |
+| TS/JS Parser | ts-morph | TypeScript Compiler API |
+| Go Parser | tree-sitter WASM | Fast, portable parsing |
 
 ## Data Flow
 

--- a/website/content/index.mdx
+++ b/website/content/index.mdx
@@ -201,9 +201,10 @@ dev mcp install           # For Claude Code
 
 - **Context Bundling** — `dev_plan` replaces 5-10 tool calls with one
 - **Code Snippets** — Search returns code, not just file paths
+- **Multi-Language** — TypeScript, JavaScript, Go, Markdown
 - **100% Local** — Your code never leaves your machine
 - **Sub-second Search** — Fast even on large repos with LanceDB
-- **1379+ Tests** — Production-grade reliability
+- **1500+ Tests** — Production-grade reliability
 
 ---
 

--- a/website/content/latest-version.ts
+++ b/website/content/latest-version.ts
@@ -4,9 +4,10 @@
  */
 
 export const latestVersion = {
-  version: '0.5.2',
-  title: 'GitHub Indexing for Large Repositories',
-  date: 'December 6, 2024',
-  summary: 'Fixed `ENOBUFS` errors when indexing repositories with many GitHub issues/PRs.',
-  link: '/updates#v052--github-indexing-for-large-repositories',
+  version: '0.6.0',
+  title: 'Go Language Support',
+  date: 'December 10, 2025',
+  summary:
+    'Full Go language support with tree-sitter — functions, methods, structs, interfaces, and generics.',
+  link: '/updates#v060--go-language-support',
 } as const;

--- a/website/content/updates/index.mdx
+++ b/website/content/updates/index.mdx
@@ -9,9 +9,73 @@ What's new in dev-agent. We ship improvements regularly to help AI assistants un
 
 ---
 
+## v0.6.0 — Go Language Support
+
+*December 10, 2025*
+
+**Full Go language support with tree-sitter.** Index Go codebases with the same quality as TypeScript — functions, methods, structs, interfaces, and generics.
+
+### What's New
+
+**🐹 Go Scanner**
+
+dev-agent now fully supports Go codebases:
+
+```go
+// All of these are now indexed and searchable:
+func NewServer(cfg Config) *Server { ... }
+func (s *Server) Start(ctx context.Context) error { ... }
+type Config struct { Host string; Port int }
+type Handler interface { Handle(ctx context.Context) error }
+type Stack[T any] struct { items []T }  // Generics!
+```
+
+**Features:**
+- Functions and methods with receiver information
+- Structs, interfaces, and type aliases
+- Go 1.18+ generics support
+- Go doc comment extraction
+- Exported symbol detection (capital letter convention)
+
+**📋 Progress Logging**
+
+New `--verbose` flag shows detailed progress:
+
+```bash
+dev index . --verbose
+[scanner] Found 4338 go files {language: "go", files: 4338}
+⠧ Embedding 4480/49151 documents (9%)
+[indexer] Embedding complete {documentsIndexed: 49151}
+```
+
+**🚫 Smart Exclusions**
+
+Generated files are automatically skipped:
+- `*.pb.go` — Protobuf
+- `*.gen.go`, `*_gen.go` — Code generators
+- `*.pb.gw.go` — gRPC gateway
+- `mock_*.go`, `mocks/` — Mock files
+- `testdata/` — Test fixtures
+
+### Why This Matters
+
+Go teams can now use dev-agent for semantic code search across their entire codebase. Search for "authentication middleware" and find your Go handlers, not just TypeScript files.
+
+**Tested on:** Large Go codebase (~4k files, 49k documents) ✅
+
+### Technical Details
+
+Go parsing uses **tree-sitter WASM** — the same parser used by GitHub, Neovim, and other tools. This provides:
+- Fast, incremental parsing
+- No Go installation required
+- Portable across platforms
+- Foundation for future Python/Rust support
+
+---
+
 ## v0.5.2 — GitHub Indexing for Large Repositories
 
-*December 6, 2024*
+*December 6, 2025*
 
 **Fixed `ENOBUFS` errors when indexing repositories with many GitHub issues/PRs.** Large active repositories can now be fully indexed without buffer overflow issues.
 
@@ -283,7 +347,8 @@ dev mcp install --cursor
 
 We're working on:
 
-- **More languages** — Better Go and Python support via tree-sitter
+- **Python support** — Using tree-sitter infrastructure from Go scanner
+- **Rust support** — Structs, traits, impl blocks
 - **Parallel search** — Query multiple repos simultaneously
 
 Have ideas? [Open an issue](https://github.com/lytics/dev-agent/issues) or join the discussion.


### PR DESCRIPTION
Update documentation for Go language support release.

**Files updated:**
- README.md - Add supported languages table, v0.6.0 version history
- AGENTS.md - Add Go to tech stack, supported languages
- CLAUDE.md - Add tree-sitter, supported languages
- website/content/index.mdx - Add multi-language feature, update test count
- website/content/docs/architecture.mdx - Add Go scanner details, language table
- website/content/updates/index.mdx - Add v0.6.0 release notes
- website/content/latest-version.ts - Update to v0.6.0

Also fixed dates from 2024 → 2025.